### PR TITLE
Start server on the test file

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ click==7.1.2
 colorama==0.4.3
 coverage==5.2.1
 docutils==0.16
+flask==1.1.2
 flit==2.3.0
 flit-core==2.3.0
 idna==2.10
@@ -33,3 +34,4 @@ typed-ast==1.4.1
 typer==0.3.1
 urllib3==1.25.10
 python-dotenv==0.14.0
+werkzeug==0.16.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import pytest
+from werkzeug.serving import make_server
+from threading import Thread
+from tests.test_webapp.app import app
+
+class ServerThread(Thread):
+
+    def __init__(self, app):
+        Thread.__init__(self)
+        self.server = make_server('127.0.0.1', 5000, app)
+        self.ctx = app.app_context()
+        self.ctx.push()
+
+    def run(self):
+        self.server.serve_forever()
+
+    def shutdown(self):
+        self.server.shutdown()
+
+@pytest.fixture(scope="session")
+def server():
+    server = ServerThread(app)
+    server.start()
+    yield server
+    server.shutdown()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,13 @@
 import pytest
 
 from typer.testing import CliRunner
-
 from pyanchor.cli import app
 
 
 runner = CliRunner()
 
 
+@pytest.mark.usefixtures('server')
 class TestCli:
     def test_exception_on_invalid_url_http_scheme(self):
         result = runner.invoke(app, ["google.com"])


### PR DESCRIPTION
#1 Was created a fixture to start a flask server before the tests and stop it when the tests finalize, with this update not is more required start the `test_webapp` to run the tests